### PR TITLE
feat(prose-polish): detect definition-restatement comments and shorte…

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -140,7 +140,7 @@
       "description": "Development workflow bundle (includes peer + extract-rules + dev-workflow + rules-review + tidy + prose-polish)",
       "source": "./plugins/dev-workflow-bundle",
       "skills": ["./skills/ask-peer", "./skills/dev-workflow", "./skills/extract-rules", "./skills/rules-review", "./skills/tidy", "./skills/prose-polish"],
-      "version": "1.92.0",
+      "version": "1.93.0",
       "author": {
         "name": "hiropon"
       },
@@ -184,7 +184,7 @@
       "description": "Refactor verbose or unnatural prose into concise, native-sounding text in a configured target language using a sonnet subagent (file mode rewrites in place, text mode returns the result)",
       "source": "./skills/prose-polish",
       "skills": ["./"],
-      "version": "1.5.0",
+      "version": "1.6.0",
       "author": {
         "name": "hiropon"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 2026-06-30
 
+### prose-polish v1.6.0 / dev-workflow-bundle v1.93.0
+
+- feat(prose-polish): detect definition-restatement comments and shorten kept *why* comments more aggressively
+  - **Behavior change**: prose-polish now auto-deletes a comment that merely restates the definition of the construct it annotates — even when it names a specific subject (e.g. a `.gitignore` entry commented "excludes `<file>`", a type annotation repeating the declared type) — and compresses a kept *why* comment to its essential reason in one sentence, trimming mechanism / causal-chain detail a competent reader can infer. Comments that previously survived may now be deleted or shortened. Deletions stay on the existing auto-applied `edits` path, so the return contract / verdict schema is unchanged
+  - Implemented entirely in `references/prose-style-guide.md`: General rule 2 gains the definition-restatement sub-case plus a "state the *why* concisely" clause, and the Japanese section's Restatement removal item gains a multi-line-*why* compression example. `SKILL.md` is unchanged — its refactor prompt already deletes fully-redundant comments via `edits` and delegates "what counts as redundant" to the style guide's "say what the code does not" rule, so widening that rule is picked up with no prompt edit
+  - canonical `skills/prose-polish/` and the `dev-workflow-bundle` copy synced byte-identical (`references/prose-style-guide.md`)
+
 ### dev-workflow v1.83.0 / dev-workflow-bundle v1.92.0
 
 - feat(dev-workflow): consolidate the Step 11.5 self-retrospective issue-submission approval into a single gate

--- a/plugins/dev-workflow-bundle/skills/prose-polish/references/prose-style-guide.md
+++ b/plugins/dev-workflow-bundle/skills/prose-polish/references/prose-style-guide.md
@@ -28,7 +28,7 @@ The preserve-test outranks the translate-default, so a recognized proper noun (`
 ## General rules (all target languages)
 
 1. **Cut filler.** Remove words that add length without meaning — restating the obvious, hedging ("basically", "essentially"), and ceremony ("it should be noted that").
-2. **Say what the code does not.** A comment that paraphrases the code it sits above is noise; keep comments that explain a non-obvious *why* (a constraint, an invariant, a workaround) and delete pure *what*-narration.
+2. **Say what the code does not.** A comment that paraphrases the code it sits above is noise: delete pure *what*-narration — including a comment that merely restates the definition of the construct it annotates, even when it names a specific subject (e.g. a `.prettierignore` / `.gitignore` entry commented "excludes `<file>`", or a type annotation whose comment repeats the declared type). Keep a comment only for a non-obvious *why* — a constraint, an invariant, a workaround — and state that *why* in one sentence, trimming mechanism or causal-chain detail a reader can infer while keeping detail needed to act correctly.
 3. **One idea per sentence.** Split runaway sentences that chain three or more clauses; merge two sentences that state the same thing.
 4. **Prefer the direct form.** Active over passive where it reads naturally, concrete nouns over abstractions, the plain verb over a nominalized phrase ("decides" over "makes a decision").
 5. **Match the surrounding register.** Keep terminology and tone consistent with the neighboring prose; do not introduce a synonym for a term already used nearby.
@@ -56,7 +56,7 @@ Models prone to verbosity tend to produce Japanese that reads as translated-from
 
 1. **Machine-translation / literal-translation tone (機械翻訳調・直訳調)** — Drop English-syntax calques: leading "〜することによって", over-use of "〜において" / "〜に関して", and literal renderings of English connectives. Rephrase into the structure a native writer would choose.
 2. **Redundant politeness and modifiers (冗長な敬体・修飾)** — Trim redundant politeness scaffolding ("〜していただく必要があります" → "〜してください" where appropriate) and stacked modifiers that add no information.
-3. **Restatement removal (重複の除去)** — Remove restatement: a sentence that repeats the previous sentence's content with different words, or a parenthetical that duplicates the main clause.
+3. **Restatement removal (重複の除去)** — Remove restatement: a sentence that repeats the previous sentence's content with different words, or a parenthetical that duplicates the main clause. General rule 2's "state that *why* in one sentence" guidance applies to multi-line *why* comments here too (e.g. 「<ビルドツールの進捗表示>が全画面スクリーンショットに写り込みビジュアル回帰が非決定的に差分化するため、test 環境では開発インジケータを無効化する」→「スクショに影響するので test 環境では開発インジケータを無効化する」).
 4. **Technical-term handling (テクニカルターム)** — Apply the `Preserve-vs-translate litmus test`: keep genuine proper-noun terms and identifiers in their original form, and translate ordinary technical vocabulary that has a natural Japanese equivalent rather than code-mixing. On a proper-noun term's first use, a short Japanese gloss in parentheses may aid comprehension.
 5. **Particle and word-order naturalness (助詞・語順)** — Fix unnatural particle choices and English-driven word order so the sentence flows as native Japanese.
 6. **Verbose politeness forms (丁寧語の過剰形)** — Where doing so does not change the meaning or nuance, shorten these over-long politeness constructions that large language models commonly produce:

--- a/skills/prose-polish/references/prose-style-guide.md
+++ b/skills/prose-polish/references/prose-style-guide.md
@@ -28,7 +28,7 @@ The preserve-test outranks the translate-default, so a recognized proper noun (`
 ## General rules (all target languages)
 
 1. **Cut filler.** Remove words that add length without meaning — restating the obvious, hedging ("basically", "essentially"), and ceremony ("it should be noted that").
-2. **Say what the code does not.** A comment that paraphrases the code it sits above is noise; keep comments that explain a non-obvious *why* (a constraint, an invariant, a workaround) and delete pure *what*-narration.
+2. **Say what the code does not.** A comment that paraphrases the code it sits above is noise: delete pure *what*-narration — including a comment that merely restates the definition of the construct it annotates, even when it names a specific subject (e.g. a `.prettierignore` / `.gitignore` entry commented "excludes `<file>`", or a type annotation whose comment repeats the declared type). Keep a comment only for a non-obvious *why* — a constraint, an invariant, a workaround — and state that *why* in one sentence, trimming mechanism or causal-chain detail a reader can infer while keeping detail needed to act correctly.
 3. **One idea per sentence.** Split runaway sentences that chain three or more clauses; merge two sentences that state the same thing.
 4. **Prefer the direct form.** Active over passive where it reads naturally, concrete nouns over abstractions, the plain verb over a nominalized phrase ("decides" over "makes a decision").
 5. **Match the surrounding register.** Keep terminology and tone consistent with the neighboring prose; do not introduce a synonym for a term already used nearby.
@@ -56,7 +56,7 @@ Models prone to verbosity tend to produce Japanese that reads as translated-from
 
 1. **Machine-translation / literal-translation tone (機械翻訳調・直訳調)** — Drop English-syntax calques: leading "〜することによって", over-use of "〜において" / "〜に関して", and literal renderings of English connectives. Rephrase into the structure a native writer would choose.
 2. **Redundant politeness and modifiers (冗長な敬体・修飾)** — Trim redundant politeness scaffolding ("〜していただく必要があります" → "〜してください" where appropriate) and stacked modifiers that add no information.
-3. **Restatement removal (重複の除去)** — Remove restatement: a sentence that repeats the previous sentence's content with different words, or a parenthetical that duplicates the main clause.
+3. **Restatement removal (重複の除去)** — Remove restatement: a sentence that repeats the previous sentence's content with different words, or a parenthetical that duplicates the main clause. General rule 2's "state that *why* in one sentence" guidance applies to multi-line *why* comments here too (e.g. 「<ビルドツールの進捗表示>が全画面スクリーンショットに写り込みビジュアル回帰が非決定的に差分化するため、test 環境では開発インジケータを無効化する」→「スクショに影響するので test 環境では開発インジケータを無効化する」).
 4. **Technical-term handling (テクニカルターム)** — Apply the `Preserve-vs-translate litmus test`: keep genuine proper-noun terms and identifiers in their original form, and translate ordinary technical vocabulary that has a natural Japanese equivalent rather than code-mixing. On a proper-noun term's first use, a short Japanese gloss in parentheses may aid comprehension.
 5. **Particle and word-order naturalness (助詞・語順)** — Fix unnatural particle choices and English-driven word order so the sentence flows as native Japanese.
 6. **Verbose politeness forms (丁寧語の過剰形)** — Where doing so does not change the meaning or nuance, shorten these over-long politeness constructions that large language models commonly produce:


### PR DESCRIPTION
…n kept why-comments more aggressively

Widen General rule 2 of the prose style guide to flag a comment that merely restates the definition of the construct it annotates as redundant what-narration, even when it names a specific subject; add a clause to state a kept why-comment in one sentence, trimming inferable mechanism/causal-chain detail while keeping detail needed to act correctly. Cross-reference that concision guidance from the Japanese section's Restatement removal item with a bilingual before/after example.

SKILL.md is unchanged: its refactor prompt already auto-deletes fully-redundant comments via edits and delegates "what counts as redundant" to the style guide, so widening the rule needs no prompt edit. Deletions stay on the existing auto-applied edits path; the return contract is unchanged.

Paired version bump: prose-polish 1.6.0 / dev-workflow-bundle 1.93.0.