### PR TITLE
fix: ship a .claude-plugin/plugin.json with every plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "description": "Get a second opinion from another Claude instance",
       "source": "./skills/ask-claude",
       "skills": ["./"],
-      "version": "1.1.3",
+      "version": "1.1.4",
       "author": {
         "name": "hiropon"
       },
@@ -21,7 +21,7 @@
       "description": "Get a second opinion from OpenAI Codex",
       "source": "./skills/ask-codex",
       "skills": ["./"],
-      "version": "1.2.2",
+      "version": "1.2.3",
       "author": {
         "name": "hiropon"
       },
@@ -32,7 +32,7 @@
       "description": "Get a second opinion from Google Gemini",
       "source": "./skills/ask-gemini",
       "skills": ["./"],
-      "version": "1.2.1",
+      "version": "1.2.2",
       "author": {
         "name": "hiropon"
       },
@@ -43,7 +43,7 @@
       "description": "Get a second opinion from GitHub Copilot",
       "source": "./skills/ask-copilot",
       "skills": ["./"],
-      "version": "1.0.3",
+      "version": "1.0.4",
       "author": {
         "name": "hiropon"
       },
@@ -54,7 +54,7 @@
       "description": "Get a second opinion from Google Antigravity",
       "source": "./skills/ask-agy",
       "skills": ["./"],
-      "version": "1.0.0",
+      "version": "1.0.1",
       "author": {
         "name": "hiropon"
       },
@@ -65,7 +65,7 @@
       "description": "Scan plugins and skills for security risks (multi-agent support)",
       "source": "./skills/security-scanner",
       "skills": ["./"],
-      "version": "1.3.0",
+      "version": "1.3.1",
       "author": {
         "name": "hiropon"
       },
@@ -76,7 +76,7 @@
       "description": "Extract project-specific coding rules from codebase for AI agents",
       "source": "./skills/extract-rules",
       "skills": ["./"],
-      "version": "1.29.0",
+      "version": "1.29.1",
       "author": {
         "name": "hiropon"
       },
@@ -87,7 +87,7 @@
       "description": "Merge portable coding rules from multiple projects into a unified rule set",
       "source": "./skills/merge-rules",
       "skills": ["./"],
-      "version": "2.1.1",
+      "version": "2.1.2",
       "author": {
         "name": "hiropon"
       },
@@ -108,7 +108,7 @@
       "description": "Peer engineer for code review, planning, and brainstorming",
       "source": "./skills/ask-peer",
       "skills": ["./"],
-      "version": "2.6.1",
+      "version": "2.6.2",
       "author": {
         "name": "hiropon"
       },
@@ -129,7 +129,7 @@
       "description": "Guided development workflow: planning, review, implementation, testing, and rule maintenance",
       "source": "./skills/dev-workflow",
       "skills": ["./"],
-      "version": "1.141.0",
+      "version": "1.141.1",
       "author": {
         "name": "hiropon"
       },
@@ -140,7 +140,7 @@
       "description": "Development workflow bundle (includes peer + extract-rules + dev-workflow + rules-review + tidy + prose-polish + mobpro)",
       "source": "./plugins/dev-workflow-bundle",
       "skills": ["./skills/ask-peer", "./skills/dev-workflow", "./skills/extract-rules", "./skills/rules-review", "./skills/tidy", "./skills/prose-polish", "./skills/mobpro"],
-      "version": "1.165.0",
+      "version": "1.165.1",
       "author": {
         "name": "hiropon"
       },
@@ -151,7 +151,7 @@
       "description": "Learning-oriented development workflow (mob-programming style): runs the same quality gates as dev-workflow, scaled to the task's assessed difficulty the same way, while pausing after every implementation unit for a diff review, so a junior engineer can follow what is being built and why. The AI drives and narrates; the junior reads each diff and asks.",
       "source": "./skills/mobpro",
       "skills": ["./"],
-      "version": "1.50.0",
+      "version": "1.50.1",
       "author": {
         "name": "hiropon"
       },
@@ -162,7 +162,7 @@
       "description": "Apply organization-wide rules to projects (filter by tech stack, merge with existing rules)",
       "source": "./skills/apply-rules",
       "skills": ["./"],
-      "version": "2.1.1",
+      "version": "2.1.2",
       "author": {
         "name": "hiropon"
       },
@@ -173,7 +173,7 @@
       "description": "Check code changes for .claude/rules/ compliance using parallel sub-agent review",
       "source": "./skills/rules-review",
       "skills": ["./"],
-      "version": "1.8.1",
+      "version": "1.8.2",
       "author": {
         "name": "hiropon"
       },
@@ -184,7 +184,7 @@
       "description": "Review changed code for reuse, quality, and efficiency, then apply cleanup edits.",
       "source": "./skills/tidy",
       "skills": ["./"],
-      "version": "1.6.0",
+      "version": "1.6.1",
       "author": {
         "name": "hiropon"
       },
@@ -195,7 +195,7 @@
       "description": "Refactor verbose or unnatural prose into concise, native-sounding text in a configured target language using a sonnet subagent (file mode rewrites in place, text mode returns the result)",
       "source": "./skills/prose-polish",
       "skills": ["./"],
-      "version": "1.8.1",
+      "version": "1.8.2",
       "author": {
         "name": "hiropon"
       },

--- a/.claude/commands/verify-plugins.md
+++ b/.claude/commands/verify-plugins.md
@@ -18,7 +18,8 @@ allowed-tools: Read, Glob, Grep, Bash(jq *), Bash(for *), Bash(echo *), Bash(if 
 ## 対象ファイル
 
 - `.claude-plugin/marketplace.json` - プラグインマニフェスト
-- `skills/*/` - スキル実体ディレクトリ（SonicGarden 方式のプラグインは直接 source に指定される）
+- `skills/*/` - スキル実体ディレクトリ（direct-skill 方式のプラグインは直接 source に指定される）
+- `*/.claude-plugin/plugin.json` - 各プラグインのマニフェスト
 - `plugins/*/` - ラッパープラグイン（bundle やエージェント依存プラグインで使用）
 
 ## プラグイン構造の 2 パターン
@@ -39,19 +40,20 @@ marketplace.json の各プラグインを `source` プレフィックスで分�
 **direct-skill 方式（`source: "./skills/..."`）**:
 - `<source>/SKILL.md` が存在すること
 - `skills: ["./"]` が明示されていること
+- `<source>/.claude-plugin/plugin.json` が存在し、`name` が marketplace.json の `name` と一致すること
 
 **wrapper 方式（`source: "./plugins/..."`）**:
 - `source` ディレクトリが存在すること
 - `<source>/skills/` がある場合、配下エントリがシンボリックリンクであること、参照先 `skills/<skill>/SKILL.md` が存在すること
 - `<source>/agents/` がある場合、各 `.md` ファイルに YAML frontmatter が存在すること
-- `<source>/.claude-plugin/plugin.json` がある場合、有効な JSON であること
+- `<source>/.claude-plugin/plugin.json` が存在し、`name` が marketplace.json の `name` と一致すること
 - bundle の場合（`skills` 配列が specific パスを含む）: `skills` 配列の各パスが `skills/<name>/SKILL.md` に解決されること、かつ `<source>/skills/` 配下のエントリセットと一致すること
 
 ### 3. バージョン整合性
 
 marketplace.json の全プラグインについて:
-- `<source>/.claude-plugin/plugin.json` が存在する場合（wrapper 方式のみ）: marketplace.json と plugin.json のバージョンが一致すること
-- それ以外: marketplace.json のバージョンのみ確認
+- `<source>/.claude-plugin/plugin.json` が `version` を宣言している場合: marketplace.json と一致すること
+- `version` を持たない plugin.json は不備ではない。marketplace.json を単一のバージョン源とし、plugin.json はそれを継承する（現在 `version` を宣言しているのは `plugins/caffeinate` と `plugins/translate` のみ）
 
 ### 4. 構文検証
 
@@ -85,12 +87,13 @@ marketplace.json の各プラグインについて、`source` プレフィック
 
 1. `<source>/SKILL.md` が存在すること
 2. `skills: ["./"]` が明示されていること
+3. `<source>/.claude-plugin/plugin.json` が存在し、`name` が marketplace.json の `name` と一致すること
 
 **wrapper 方式（`source: "./plugins/..."`）**:
 
 1. `source` ディレクトリが存在すること
 2. `<source>/skills/` がある場合、配下エントリが **シンボリックリンク（参照先 `skills/<skill>/SKILL.md` が存在）または `SKILL.md` を含む実ディレクトリ** であること。全 wrapper は commit `56026cb` で symlink から実コピーへ変換済み（[anthropics/claude-code#53948](https://github.com/anthropics/claude-code/issues/53948) 回避）なので、実ディレクトリを不備として報告しないこと（source of truth: `.claude/rules/project.rules.md` § プラグイン構造 の wrapper エントリ bullet）
-3. `<source>/agents/` がある場合、各 `.md` に YAML frontmatter が存在すること
+3. `<source>/agents/` がある場合、各 `.md` に YAML frontmatter が存在すること。`<source>/.claude-plugin/plugin.json` が存在し、`name` が marketplace.json の `name` と一致すること
 4. **bundle の場合** (`skills` 配列が specific パスを含む): 配列内の各パスが `skills/<name>/SKILL.md` に解決されること、かつ `<source>/skills/` 配下のエントリセットと `skills` 配列のセットが一致すること（どちらか一方にしかないエントリを検出）
 
 ```bash
@@ -105,7 +108,7 @@ test -f plugins/<name>/skills/<skill-name>/SKILL.md
 marketplace.json の全プラグインについて:
 
 1. marketplace.json のバージョンを取得
-2. `<source>/.claude-plugin/plugin.json` が存在する場合（wrapper 方式のみ）、そのバージョンを取得し一致を確認
+2. `<source>/.claude-plugin/plugin.json` が `version` を宣言している場合、そのバージョンを取得し一致を確認。`version` の無い plugin.json は marketplace.json のバージョンを継承するため、不一致として扱わない
 
 不一致がある場合は警告として記録してください。
 
@@ -115,6 +118,7 @@ marketplace.json の全プラグインについて:
 
 ```bash
 jq . plugins/<plugin>/.claude-plugin/plugin.json > /dev/null
+jq . skills/<skill-dir>/.claude-plugin/plugin.json > /dev/null
 ```
 
 ### Step 6: フロントマター存在確認
@@ -194,7 +198,7 @@ Skill(skill: "check-cli-updates")
 |-----------|-------------|-------------|------|
 | translate | 1.1.1 | 1.1.1 | ✅ |
 | caffeinate | 1.0.0 | 1.0.0 | ✅ |
-| ask-claude | 1.1.3 | N/A | ✅ |
+| ask-claude | 1.1.3 | 継承 | ✅ |
 | ... | ... | ... | ... |
 
 ### 構文検証
@@ -202,7 +206,7 @@ Skill(skill: "check-cli-updates")
 |------|------|---------------|------|
 | translate | ✅ | ✅ | ✅ |
 | caffeinate | ✅ | ✅ | ✅ |
-| ask-claude | N/A | ✅ | ✅ |
+| ask-claude | ✅ | ✅ | ✅ |
 | ... | ... | ... | ... |
 
 ### 動作テスト

--- a/.claude/rules/project.rules.md
+++ b/.claude/rules/project.rules.md
@@ -92,9 +92,10 @@
 ## プラグイン構造
 
 - 単体スキルプラグインは direct-skill 方式（`source: "./skills/<skill-dir>"` + `skills: ["./"]`）を使う。`plugins/` 配下のラッパーディレクトリを作らない
+- **全プラグインの source 直下に `.claude-plugin/plugin.json` を置く**（direct-skill 方式も例外ではない）。マニフェストが無いとインストール後のキャッシュディレクトリ名からプラグイン名が推定され、名前空間の重複と別プラグイン同士の合流が起きる（[anthropics/claude-code#76234](https://github.com/anthropics/claude-code/issues/76234)）。`name` は marketplace.json の `name` と一致させる。`version` は書かない — marketplace.json を単一のバージョン源とし、plugin.json はそれを継承する（既存の `plugins/caffeinate` と `plugins/translate` だけが `version` を持ち、bump 時は marketplace.json とペアで更新する）
 - direct-skill 方式ではプラグイン名と skill ディレクトリ名が異なっても OK（例: plugin `peer` → skill `ask-peer`）
 - wrapper 方式（`plugins/<name>/`）は以下のいずれかに該当する場合のみ: (1) `agents/` を持つエージェント依存プラグイン、(2) `plugin.json` にフック定義を持つプラグイン、(3) 複数スキル bundle
-- wrapper には 2 サブパターン: (A) エージェント/フック wrapper（`plugin.json` 必須）、(B) bundle wrapper（`plugin.json` 不要、marketplace.json 側の `skills` 配列で参照スキルを明示）
+- wrapper には 2 サブパターン: (A) エージェント/フック wrapper、(B) bundle wrapper（marketplace.json 側の `skills` 配列で参照スキルを明示）
 - bundle では marketplace.json の `skills` 配列と `plugins/<bundle>/skills/` 配下のエントリセットを必ず一致させる。ずれると配布が壊れるため、`/verify-plugins` と `run-tests` で整合性を検証すること
 - **wrapper 配下の `skills/` エントリは symlink ではなく実ディレクトリコピー**。upstream の plugin cache が symlink を解決しない bug（[anthropics/claude-code#53948](https://github.com/anthropics/claude-code/issues/53948)）を回避するための暫定対応。検証ツール（`run-tests` の check 3、`/verify-plugins`）は symlink を要求せず、`SKILL.md` を含む実ディレクトリを合格として扱うこと — 要求したままにすると全 wrapper が毎回 FAIL し、恒常 FAIL が新規問題の検出を潰す。symlink 復活時は本 bullet と各検証ツールの exemption 記述をまとめて削除する
 - フックの自動設定が必要な場合はプラグイン化

--- a/.claude/skills/run-tests/SKILL.md
+++ b/.claude/skills/run-tests/SKILL.md
@@ -28,14 +28,14 @@ This project is a Claude Code plugins marketplace. "Tests" here means verifying 
 > 2. **Skill entity existence**: Verify each `skills/*/` directory contains `SKILL.md`.
 >
 > 3. **Plugin source directory structure**: For each plugin in marketplace.json, dispatch by `source` prefix:
->    - **If `source` starts with `./skills/`** (direct-skill plugin): verify `<source>/SKILL.md` exists and `skills: ["./"]` is present
->    - **If `source` starts with `./plugins/`** (wrapper plugin): verify `<source>/` exists; if `<source>/skills/` exists, each entry under it must be **either** a symlink (use `readlink`) resolving to an existing `skills/<skill>/SKILL.md` **or** a real directory containing `SKILL.md`; if `<source>/agents/` exists, each `.md` file must have YAML frontmatter; if `<source>/.claude-plugin/plugin.json` exists, its JSON must be valid
+>    - **If `source` starts with `./skills/`** (direct-skill plugin): verify `<source>/SKILL.md` exists, `skills: ["./"]` is present, and `<source>/.claude-plugin/plugin.json` exists with a `name` equal to the marketplace entry's `name`
+>    - **If `source` starts with `./plugins/`** (wrapper plugin): verify `<source>/` exists; if `<source>/skills/` exists, each entry under it must be **either** a symlink (use `readlink`) resolving to an existing `skills/<skill>/SKILL.md` **or** a real directory containing `SKILL.md`; if `<source>/agents/` exists, each `.md` file must have YAML frontmatter; `<source>/.claude-plugin/plugin.json` must exist with a `name` equal to the marketplace entry's `name`
 >      - **Real directories are expected, not a defect.** Do **not** report a real directory as a broken/missing symlink. Content equality between a real-directory copy and its canonical `skills/<name>/` is **out of scope here**: `verify-bundle-sync` owns that check
 >    - **Additionally, for wrapper bundles** (wrapper plugin with `skills` array of specific paths like `./skills/<name>`): verify each path in `skills` array resolves to an existing `skills/<name>/SKILL.md`, AND verify the set of paths matches the set of entries under `<source>/skills/` (each entry has a corresponding `skills` entry, and vice versa — detect drift in either direction)
 >
-> 4. **Version consistency**: For each plugin, if `<source>/.claude-plugin/plugin.json` exists (only possible for `./plugins/` sources), verify its `version` matches marketplace.json.
+> 4. **Version consistency**: For each plugin, if `<source>/.claude-plugin/plugin.json` declares a `version`, verify it matches marketplace.json. A manifest with no `version` field is correct, not a defect — `marketplace.json` is the single version source, and the manifest inherits it. Only `plugins/caffeinate` and `plugins/translate` currently declare one.
 >
-> 5. **JSON syntax**: Validate `.claude-plugin/marketplace.json` and every `plugins/*/.claude-plugin/plugin.json` with `jq empty`.
+> 5. **JSON syntax**: Validate `.claude-plugin/marketplace.json` and every `plugins/*/.claude-plugin/plugin.json` and `skills/*/.claude-plugin/plugin.json` with `jq empty`.
 >
 > 6. **Frontmatter presence**: Verify each `skills/*/SKILL.md` and each agent file (`plugins/*/agents/*.md`) starts with `---` on the first line (YAML frontmatter).
 >

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 2026-09-01
 
+### ask-claude v1.1.4 / ask-codex v1.2.3 / ask-gemini v1.2.2 / ask-copilot v1.0.4 / ask-agy v1.0.1 / security-scanner v1.3.1 / extract-rules v1.29.1 / merge-rules v2.1.2 / peer v2.6.2 / apply-rules v2.1.2 / rules-review v1.8.2 / tidy v1.6.1 / prose-polish v1.8.2 / dev-workflow v1.141.1 / mobpro v1.50.1 / dev-workflow-bundle v1.165.1
+
+- fix: ship a `.claude-plugin/plugin.json` with every plugin
+  - A plugin defined only by its `marketplace.json` entry installs into a cache directory that carries no manifest, and a session loading it inline then takes the plugin name from that directory's basename — the version string. Every component of such a plugin appears twice, once under its real name and once under `<version>:`, and two manifest-less plugins sharing a version string merge into one namespace ([anthropics/claude-code#76234](https://github.com/anthropics/claude-code/issues/76234)). The 15 direct-skill plugins and `dev-workflow-bundle` now each carry a manifest, so the name is read from the manifest instead. `caffeinate` and `translate` already had one.
+  - The new manifests declare no `version`: `marketplace.json` stays the single version source and each manifest inherits from it. Only the two pre-existing wrapper manifests declare a version, and those stay paired with their marketplace entry.
+  - Version-consistency checks in `run-tests` and `/verify-plugins` now treat a manifest without a `version` as correct rather than as a mismatch, and both require the manifest's `name` to match the marketplace entry so a future plugin cannot ship without one. The patch bumps here are what makes the manifests reach installs that already exist.
+
 ### dev-workflow v1.141.0 / mobpro v1.50.0 / extract-rules v1.29.0 / tidy v1.6.0 / dev-workflow-bundle v1.165.0
 
 - refactor(dev-workflow, mobpro, extract-rules, tidy): drop the deprecated `TodoWrite` progress-tracking layer

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,13 +15,15 @@ Claude Code用プラグインを公開するためのマーケットプレイス
 │   └── marketplace.json      # プラグインマニフェスト
 ├── skills/                   # SKILL.mdの実体かつ単体スキルプラグインのsource
 │   └── <skill-name>/
+│       ├── .claude-plugin/   # direct-skill 方式で source になるスキルのみ
+│       │   └── plugin.json
 │       ├── SKILL.md
 │       └── README.md         # (任意、ユーザー向け設定リファレンスなど)
 ├── plugins/                  # wrapper 方式のプラグインのみ
 │   └── <plugin-name>/
 │       ├── skills/           # bundle の場合、複数 skill 分のエントリ
 │       │   └── <skill-name>  # skills/<skill-name> の実ディレクトリコピー
-│       ├── .claude-plugin/   # (エージェント依存 / フック定義プラグイン)
+│       ├── .claude-plugin/
 │       │   └── plugin.json
 │       ├── agents/           # (エージェント依存プラグインのみ)
 │       │   └── <agent-name>.md
@@ -38,6 +40,14 @@ Claude Code用プラグインを公開するためのマーケットプレイス
 
 **注意:** marketplace.json で `source: "./"` を使ってはいけない。`skills/` 配下の全スキルが自動発見されて重複登録される（[anthropics/claude-code#13344](https://github.com/anthropics/claude-code/issues/13344)）。必ず `./skills/<skill-dir>` または `./plugins/<plugin-name>` のように specific なパスを指定する。
 
+## プラグインマニフェスト
+
+**全プラグインが `<source>/.claude-plugin/plugin.json` を持つ。** direct-skill 方式・wrapper 方式のどちらも例外なし。マニフェストの無いプラグインは、インストール後のキャッシュディレクトリ名（バージョン文字列）からプラグイン名が推定され、同名前空間の重複・別プラグイン同士の合流が起きる（[anthropics/claude-code#76234](https://github.com/anthropics/claude-code/issues/76234)）。
+
+- `name` は marketplace.json の `name` と一致させる。スキルディレクトリ名とは異なってよい（例: plugin `peer` → `skills/ask-peer/`）
+- `version` は書かない。marketplace.json を単一のバージョン源とし、plugin.json はそれを継承する。両方に書くとバージョン更新のたびに 2 ファイル編集が必要になる
+- 例外は既存の `plugins/caffeinate` と `plugins/translate` の 2 つ。どちらも `version` を持つため、bump 時は marketplace.json とペアで更新する
+
 ## スキル追加フロー（direct-skill 方式 / エージェント非依存）
 
 スキルが `allowed-tools` を持ち、エージェント / フック定義に依存しない場合。`plugins/` 配下のラッパーは作らない。
@@ -46,6 +56,8 @@ Claude Code用プラグインを公開するためのマーケットプレイス
 
 ```text
 skills/<skill-name>/
+├── .claude-plugin/
+│   └── plugin.json
 ├── SKILL.md
 └── README.md   # (任意、設定が複雑ならユーザー向けリファレンスを追加)
 ```
@@ -64,7 +76,23 @@ allowed-tools: Read, Glob, Grep
 スキルの詳細な説明と使い方
 ```
 
-### 3. marketplace.json に追加
+### 3. plugin.json
+
+`.claude-plugin/plugin.json` を置く。プラグイン名は marketplace.json の `name` と一致させる（スキルディレクトリ名とは異なってよい）。`version` は書かない（marketplace.json を単一のバージョン源とする）。理由は「プラグインマニフェスト」節を参照。
+
+```json
+{
+  "name": "<plugin-name>",
+  "description": "スキルの説明",
+  "author": { "name": "hiropon", "url": "https://github.com/hiroro-work" },
+  "homepage": "https://github.com/hiroro-work/claude-plugins",
+  "repository": "https://github.com/hiroro-work/claude-plugins",
+  "license": "MIT",
+  "keywords": ["keyword1", "keyword2"]
+}
+```
+
+### 4. marketplace.json に追加
 
 `.claude-plugin/marketplace.json` の `plugins` 配列に追加（プラグイン名とスキル名が異なっても OK、例: plugin `peer` → skill `ask-peer`）:
 
@@ -80,13 +108,13 @@ allowed-tools: Read, Glob, Grep
 }
 ```
 
-### 4. 開発・テスト用シンボリックリンク作成
+### 5. 開発・テスト用シンボリックリンク作成
 
 ```bash
 ln -s ../../skills/<skill-name> .claude/skills/<skill-name>
 ```
 
-### 5. CHANGELOG.md 更新
+### 6. CHANGELOG.md 更新
 
 ## プラグイン追加フロー（wrapper 方式）
 
@@ -95,7 +123,7 @@ wrapper には **2 つのサブパターン** がある。必要なファイル�
 | サブパターン | 用途 | `.claude-plugin/plugin.json` | `agents/` | `skills/` |
 |---|---|---|---|---|
 | **A. エージェント / フック wrapper** | エージェント依存 (`translate`)、フック定義 (`caffeinate`) | 必須 | エージェント依存なら必須 | 単一スキルのエントリ |
-| **B. bundle wrapper** | 複数スキルの束 (`dev-workflow-bundle`) | 不要 | 不要 | 複数スキルのエントリ + marketplace.json の `skills` 配列 |
+| **B. bundle wrapper** | 複数スキルの束 (`dev-workflow-bundle`) | 必須 | 不要 | 複数スキルのエントリ + marketplace.json の `skills` 配列 |
 
 ### サブパターン A: エージェント / フック wrapper
 
@@ -126,7 +154,6 @@ ln -s ../../../skills/<skill-name> plugins/<plugin-name>/skills/<skill-name>
 ```json
 {
   "name": "<plugin-name>",
-  "version": "1.0.0",
   "description": "プラグインの説明",
   "author": {
     "name": "hiroro-work",
@@ -156,10 +183,12 @@ ln -s ../../../skills/<skill-name> plugins/<plugin-name>/skills/<skill-name>
 
 ### サブパターン B: bundle wrapper
 
-#### B-1. プラグインディレクトリ作成（plugin.json は不要）
+#### B-1. プラグインディレクトリ作成
 
 ```text
 plugins/<bundle-name>/
+├── .claude-plugin/
+│   └── plugin.json
 └── skills/
     ├── <skill-a>  # → ../../../skills/<skill-a>
     ├── <skill-b>  # → ../../../skills/<skill-b>

--- a/plugins/dev-workflow-bundle/.claude-plugin/plugin.json
+++ b/plugins/dev-workflow-bundle/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "dev-workflow-bundle",
+  "description": "Development workflow bundle (includes peer + extract-rules + dev-workflow + rules-review + tidy + prose-polish + mobpro)",
+  "author": {
+    "name": "hiropon",
+    "url": "https://github.com/hiroro-work"
+  },
+  "homepage": "https://github.com/hiroro-work/claude-plugins",
+  "repository": "https://github.com/hiroro-work/claude-plugins",
+  "license": "MIT",
+  "keywords": [
+    "workflow",
+    "bundle",
+    "planning",
+    "code-review",
+    "testing",
+    "rules"
+  ]
+}

--- a/plugins/dev-workflow-bundle/skills/ask-peer/.claude-plugin/plugin.json
+++ b/plugins/dev-workflow-bundle/skills/ask-peer/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "peer",
+  "description": "Peer engineer for code review, planning, and brainstorming",
+  "author": {
+    "name": "hiropon",
+    "url": "https://github.com/hiroro-work"
+  },
+  "homepage": "https://github.com/hiroro-work/claude-plugins",
+  "repository": "https://github.com/hiroro-work/claude-plugins",
+  "license": "MIT",
+  "keywords": [
+    "peer-review",
+    "code-review",
+    "planning",
+    "brainstorming"
+  ]
+}

--- a/plugins/dev-workflow-bundle/skills/dev-workflow/.claude-plugin/plugin.json
+++ b/plugins/dev-workflow-bundle/skills/dev-workflow/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "dev-workflow",
+  "description": "Guided development workflow: planning, review, implementation, testing, and rule maintenance",
+  "author": {
+    "name": "hiropon",
+    "url": "https://github.com/hiroro-work"
+  },
+  "homepage": "https://github.com/hiroro-work/claude-plugins",
+  "repository": "https://github.com/hiroro-work/claude-plugins",
+  "license": "MIT",
+  "keywords": [
+    "workflow",
+    "planning",
+    "code-review",
+    "testing",
+    "rules"
+  ]
+}

--- a/plugins/dev-workflow-bundle/skills/extract-rules/.claude-plugin/plugin.json
+++ b/plugins/dev-workflow-bundle/skills/extract-rules/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "extract-rules",
+  "description": "Extract project-specific coding rules from codebase for AI agents",
+  "author": {
+    "name": "hiropon",
+    "url": "https://github.com/hiroro-work"
+  },
+  "homepage": "https://github.com/hiroro-work/claude-plugins",
+  "repository": "https://github.com/hiroro-work/claude-plugins",
+  "license": "MIT",
+  "keywords": [
+    "rules",
+    "conventions",
+    "documentation",
+    "onboarding"
+  ]
+}

--- a/plugins/dev-workflow-bundle/skills/mobpro/.claude-plugin/plugin.json
+++ b/plugins/dev-workflow-bundle/skills/mobpro/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "mobpro",
+  "description": "Learning-oriented development workflow (mob-programming style): runs the same quality gates as dev-workflow, scaled to the task's assessed difficulty the same way, while pausing after every implementation unit for a diff review, so a junior engineer can follow what is being built and why. The AI drives and narrates; the junior reads each diff and asks.",
+  "author": {
+    "name": "hiropon",
+    "url": "https://github.com/hiroro-work"
+  },
+  "homepage": "https://github.com/hiroro-work/claude-plugins",
+  "repository": "https://github.com/hiroro-work/claude-plugins",
+  "license": "MIT",
+  "keywords": [
+    "mob-programming",
+    "workflow",
+    "learning",
+    "pair-programming"
+  ]
+}

--- a/plugins/dev-workflow-bundle/skills/prose-polish/.claude-plugin/plugin.json
+++ b/plugins/dev-workflow-bundle/skills/prose-polish/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "prose-polish",
+  "description": "Refactor verbose or unnatural prose into concise, native-sounding text in a configured target language using a sonnet subagent (file mode rewrites in place, text mode returns the result)",
+  "author": {
+    "name": "hiropon",
+    "url": "https://github.com/hiroro-work"
+  },
+  "homepage": "https://github.com/hiroro-work/claude-plugins",
+  "repository": "https://github.com/hiroro-work/claude-plugins",
+  "license": "MIT",
+  "keywords": [
+    "prose",
+    "refactor",
+    "writing",
+    "localization"
+  ]
+}

--- a/plugins/dev-workflow-bundle/skills/rules-review/.claude-plugin/plugin.json
+++ b/plugins/dev-workflow-bundle/skills/rules-review/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "rules-review",
+  "description": "Check code changes for .claude/rules/ compliance using parallel sub-agent review",
+  "author": {
+    "name": "hiropon",
+    "url": "https://github.com/hiroro-work"
+  },
+  "homepage": "https://github.com/hiroro-work/claude-plugins",
+  "repository": "https://github.com/hiroro-work/claude-plugins",
+  "license": "MIT",
+  "keywords": [
+    "rules",
+    "compliance",
+    "review",
+    "conventions"
+  ]
+}

--- a/plugins/dev-workflow-bundle/skills/tidy/.claude-plugin/plugin.json
+++ b/plugins/dev-workflow-bundle/skills/tidy/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "tidy",
+  "description": "Review changed code for reuse, quality, and efficiency, then apply cleanup edits.",
+  "author": {
+    "name": "hiropon",
+    "url": "https://github.com/hiroro-work"
+  },
+  "homepage": "https://github.com/hiroro-work/claude-plugins",
+  "repository": "https://github.com/hiroro-work/claude-plugins",
+  "license": "MIT",
+  "keywords": [
+    "cleanup",
+    "refactor",
+    "code-quality",
+    "review"
+  ]
+}

--- a/skills/apply-rules/.claude-plugin/plugin.json
+++ b/skills/apply-rules/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "apply-rules",
+  "description": "Apply organization-wide rules to projects (filter by tech stack, merge with existing rules)",
+  "author": {
+    "name": "hiropon",
+    "url": "https://github.com/hiroro-work"
+  },
+  "homepage": "https://github.com/hiroro-work/claude-plugins",
+  "repository": "https://github.com/hiroro-work/claude-plugins",
+  "license": "MIT",
+  "keywords": [
+    "rules",
+    "apply",
+    "conventions",
+    "tech-stack"
+  ]
+}

--- a/skills/ask-agy/.claude-plugin/plugin.json
+++ b/skills/ask-agy/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "ask-agy",
+  "description": "Get a second opinion from Google Antigravity",
+  "author": {
+    "name": "hiropon",
+    "url": "https://github.com/hiroro-work"
+  },
+  "homepage": "https://github.com/hiroro-work/claude-plugins",
+  "repository": "https://github.com/hiroro-work/claude-plugins",
+  "license": "MIT",
+  "keywords": [
+    "antigravity",
+    "google",
+    "second-opinion",
+    "code-review",
+    "cli"
+  ]
+}

--- a/skills/ask-claude/.claude-plugin/plugin.json
+++ b/skills/ask-claude/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "ask-claude",
+  "description": "Get a second opinion from another Claude instance",
+  "author": {
+    "name": "hiropon",
+    "url": "https://github.com/hiroro-work"
+  },
+  "homepage": "https://github.com/hiroro-work/claude-plugins",
+  "repository": "https://github.com/hiroro-work/claude-plugins",
+  "license": "MIT",
+  "keywords": [
+    "claude",
+    "second-opinion",
+    "code-review",
+    "cli"
+  ]
+}

--- a/skills/ask-codex/.claude-plugin/plugin.json
+++ b/skills/ask-codex/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "ask-codex",
+  "description": "Get a second opinion from OpenAI Codex",
+  "author": {
+    "name": "hiropon",
+    "url": "https://github.com/hiroro-work"
+  },
+  "homepage": "https://github.com/hiroro-work/claude-plugins",
+  "repository": "https://github.com/hiroro-work/claude-plugins",
+  "license": "MIT",
+  "keywords": [
+    "codex",
+    "openai",
+    "second-opinion",
+    "code-review",
+    "cli"
+  ]
+}

--- a/skills/ask-copilot/.claude-plugin/plugin.json
+++ b/skills/ask-copilot/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "ask-copilot",
+  "description": "Get a second opinion from GitHub Copilot",
+  "author": {
+    "name": "hiropon",
+    "url": "https://github.com/hiroro-work"
+  },
+  "homepage": "https://github.com/hiroro-work/claude-plugins",
+  "repository": "https://github.com/hiroro-work/claude-plugins",
+  "license": "MIT",
+  "keywords": [
+    "copilot",
+    "github",
+    "second-opinion",
+    "code-review",
+    "cli"
+  ]
+}

--- a/skills/ask-gemini/.claude-plugin/plugin.json
+++ b/skills/ask-gemini/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "ask-gemini",
+  "description": "Get a second opinion from Google Gemini",
+  "author": {
+    "name": "hiropon",
+    "url": "https://github.com/hiroro-work"
+  },
+  "homepage": "https://github.com/hiroro-work/claude-plugins",
+  "repository": "https://github.com/hiroro-work/claude-plugins",
+  "license": "MIT",
+  "keywords": [
+    "gemini",
+    "google",
+    "second-opinion",
+    "code-review",
+    "cli"
+  ]
+}

--- a/skills/ask-peer/.claude-plugin/plugin.json
+++ b/skills/ask-peer/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "peer",
+  "description": "Peer engineer for code review, planning, and brainstorming",
+  "author": {
+    "name": "hiropon",
+    "url": "https://github.com/hiroro-work"
+  },
+  "homepage": "https://github.com/hiroro-work/claude-plugins",
+  "repository": "https://github.com/hiroro-work/claude-plugins",
+  "license": "MIT",
+  "keywords": [
+    "peer-review",
+    "code-review",
+    "planning",
+    "brainstorming"
+  ]
+}

--- a/skills/dev-workflow/.claude-plugin/plugin.json
+++ b/skills/dev-workflow/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "dev-workflow",
+  "description": "Guided development workflow: planning, review, implementation, testing, and rule maintenance",
+  "author": {
+    "name": "hiropon",
+    "url": "https://github.com/hiroro-work"
+  },
+  "homepage": "https://github.com/hiroro-work/claude-plugins",
+  "repository": "https://github.com/hiroro-work/claude-plugins",
+  "license": "MIT",
+  "keywords": [
+    "workflow",
+    "planning",
+    "code-review",
+    "testing",
+    "rules"
+  ]
+}

--- a/skills/extract-rules/.claude-plugin/plugin.json
+++ b/skills/extract-rules/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "extract-rules",
+  "description": "Extract project-specific coding rules from codebase for AI agents",
+  "author": {
+    "name": "hiropon",
+    "url": "https://github.com/hiroro-work"
+  },
+  "homepage": "https://github.com/hiroro-work/claude-plugins",
+  "repository": "https://github.com/hiroro-work/claude-plugins",
+  "license": "MIT",
+  "keywords": [
+    "rules",
+    "conventions",
+    "documentation",
+    "onboarding"
+  ]
+}

--- a/skills/merge-rules/.claude-plugin/plugin.json
+++ b/skills/merge-rules/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "merge-rules",
+  "description": "Merge portable coding rules from multiple projects into a unified rule set",
+  "author": {
+    "name": "hiropon",
+    "url": "https://github.com/hiroro-work"
+  },
+  "homepage": "https://github.com/hiroro-work/claude-plugins",
+  "repository": "https://github.com/hiroro-work/claude-plugins",
+  "license": "MIT",
+  "keywords": [
+    "rules",
+    "merge",
+    "portable",
+    "conventions"
+  ]
+}

--- a/skills/mobpro/.claude-plugin/plugin.json
+++ b/skills/mobpro/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "mobpro",
+  "description": "Learning-oriented development workflow (mob-programming style): runs the same quality gates as dev-workflow, scaled to the task's assessed difficulty the same way, while pausing after every implementation unit for a diff review, so a junior engineer can follow what is being built and why. The AI drives and narrates; the junior reads each diff and asks.",
+  "author": {
+    "name": "hiropon",
+    "url": "https://github.com/hiroro-work"
+  },
+  "homepage": "https://github.com/hiroro-work/claude-plugins",
+  "repository": "https://github.com/hiroro-work/claude-plugins",
+  "license": "MIT",
+  "keywords": [
+    "mob-programming",
+    "workflow",
+    "learning",
+    "pair-programming"
+  ]
+}

--- a/skills/prose-polish/.claude-plugin/plugin.json
+++ b/skills/prose-polish/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "prose-polish",
+  "description": "Refactor verbose or unnatural prose into concise, native-sounding text in a configured target language using a sonnet subagent (file mode rewrites in place, text mode returns the result)",
+  "author": {
+    "name": "hiropon",
+    "url": "https://github.com/hiroro-work"
+  },
+  "homepage": "https://github.com/hiroro-work/claude-plugins",
+  "repository": "https://github.com/hiroro-work/claude-plugins",
+  "license": "MIT",
+  "keywords": [
+    "prose",
+    "refactor",
+    "writing",
+    "localization"
+  ]
+}

--- a/skills/rules-review/.claude-plugin/plugin.json
+++ b/skills/rules-review/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "rules-review",
+  "description": "Check code changes for .claude/rules/ compliance using parallel sub-agent review",
+  "author": {
+    "name": "hiropon",
+    "url": "https://github.com/hiroro-work"
+  },
+  "homepage": "https://github.com/hiroro-work/claude-plugins",
+  "repository": "https://github.com/hiroro-work/claude-plugins",
+  "license": "MIT",
+  "keywords": [
+    "rules",
+    "compliance",
+    "review",
+    "conventions"
+  ]
+}

--- a/skills/security-scanner/.claude-plugin/plugin.json
+++ b/skills/security-scanner/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "security-scanner",
+  "description": "Scan plugins and skills for security risks (multi-agent support)",
+  "author": {
+    "name": "hiropon",
+    "url": "https://github.com/hiroro-work"
+  },
+  "homepage": "https://github.com/hiroro-work/claude-plugins",
+  "repository": "https://github.com/hiroro-work/claude-plugins",
+  "license": "MIT",
+  "keywords": [
+    "security",
+    "scanner",
+    "audit",
+    "plugins",
+    "skills"
+  ]
+}

--- a/skills/tidy/.claude-plugin/plugin.json
+++ b/skills/tidy/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "tidy",
+  "description": "Review changed code for reuse, quality, and efficiency, then apply cleanup edits.",
+  "author": {
+    "name": "hiropon",
+    "url": "https://github.com/hiroro-work"
+  },
+  "homepage": "https://github.com/hiroro-work/claude-plugins",
+  "repository": "https://github.com/hiroro-work/claude-plugins",
+  "license": "MIT",
+  "keywords": [
+    "cleanup",
+    "refactor",
+    "code-quality",
+    "review"
+  ]
+}


### PR DESCRIPTION
A plugin defined only by its marketplace.json entry installs into a cache directory that carries no manifest, and a session loading it inline then takes the plugin name from that directory's basename -- the version string. Every component of such a plugin appears twice, once under its real name and once under `<version>:`, and two manifest-less plugins sharing a version string merge into one namespace (anthropics/claude-code#76234).

The 15 direct-skill plugins and dev-workflow-bundle now each carry a manifest. caffeinate and translate already had one.

The new manifests declare no `version`: marketplace.json stays the single version source and each manifest inherits from it. Declaring it in both would make every bump a two-file edit per plugin, and the auto-triage bookkeeping commits -- which bump marketplace.json alone -- would start failing run-tests Check 4.

The bundle copies under plugins/dev-workflow-bundle/skills/ pick up a nested manifest each, since they are byte-identical copies of sources that are themselves standalone plugins. Those are inert -- only the plugin root's manifest is consulted -- and excluding them would require patching verify-bundle-sync's `diff -rq` and the `cp -R` remediation command it prints.

Swept with it: run-tests Checks 3/4/5, /verify-plugins, CLAUDE.md's new plugin-manifest section and direct-skill flow, and the .claude/rules/ plugin-structure bullet. The patch bumps are what makes the manifests reach installs that already exist.